### PR TITLE
Restore 'lookat' in simple example

### DIFF
--- a/examples/simple.html
+++ b/examples/simple.html
@@ -14,6 +14,7 @@
 			var hyperlapse = new Hyperlapse(document.getElementById('pano'), {
 				zoom: 2,
 				use_lookat: true,
+				lookat: new google.maps.LatLng(37.81409525128964,-122.4775045005249),
 				elevation: 50
 			});
 


### PR DESCRIPTION
I found that the simple.html example no longer worked because it has use_lookat: true but no lookat.

Unless I'm missing something, this is just an oversight.  This commit simply restores the lookat to simple.html.
