### PR TITLE
Full-time rendering

### DIFF
--- a/src/Hyperlapse.js
+++ b/src/Hyperlapse.js
@@ -140,7 +140,8 @@ var Hyperlapse = function(container, params) {
 		_ctime = Date.now(),
 		_ptime = 0, _dtime = 0,
 		_prev_pano_id = null,
-		_raw_points = [], _h_points = [];
+		_raw_points = [], _h_points = [],
+		_raf;
 
 	/**
 	 * @event Hyperlapse#onError
@@ -247,8 +248,6 @@ var Hyperlapse = function(container, params) {
 	var handleLoadComplete = function (e) {
 		_is_loading = false;
 		_point_index = 0;
-
-		animate();
 
 		if (self.onLoadComplete) self.onLoadComplete(e);
 	};
@@ -493,7 +492,7 @@ var Hyperlapse = function(container, params) {
 			_dtime = 0;
 		}
 
-		requestAnimationFrame( animate );
+		_raf = requestAnimationFrame( animate );
 		render();
 	};
 
@@ -747,6 +746,7 @@ var Hyperlapse = function(container, params) {
 	this.play = function() {
 		if(!_is_loading) {
 			_is_playing = true;
+        	animate();
 			handlePlay({});
 		} 
 	};
@@ -757,6 +757,7 @@ var Hyperlapse = function(container, params) {
 	 */
 	this.pause = function() {
 		_is_playing = false;
+   		cancelAnimationFrame(_raf);
 		handlePause({});
 	};
 


### PR DESCRIPTION
Hi there,

I'm not a specialist of Three.js and WebGLRendering, but I was exploring the source code of this excellent stuff, and just found that the requestAnimationFrame is launched automatically at the loading end event.

I wonder if it is not better to launch it on the play callback, then cancel it on the pause one ?

I'm joining a few lines of code that may interest you !

It's still using requestAnimationFrame(), and now cancelAnimationFrame(), that should be overwritten by a polyfill, that is not included, like in this way: http://paulirish.com/2011/requestanimationframe-for-smart-animating/
